### PR TITLE
CMake required version updated for compatibility with latest cmakes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(QZXing)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS


### PR DESCRIPTION
Without this change `qzxing` build fails on machines with CMake version 4